### PR TITLE
feat!: complete singletons removal

### DIFF
--- a/Example/SwiftAudioPlayer/AppDelegate.swift
+++ b/Example/SwiftAudioPlayer/AppDelegate.swift
@@ -40,7 +40,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-    func application(_: UIApplication, handleEventsForBackgroundURLSession _: String, completionHandler: @escaping () -> Void) {
-        SAPlayer.Downloader.setBackgroundCompletionHandler(completionHandler)
+    func application(_: UIApplication, handleEventsForBackgroundURLSession _: String, completionHandler _: @escaping () -> Void) {
+        // Keep as reminder, but how can we access the player here? Or can we hook on this in other parts of our code?
+        // SAPlayer.Downloader(manager: AudioDataManager()).setBackgroundCompletionHandler(completionHandler)
     }
 }

--- a/Source/Directors/AudioClockDirector.swift
+++ b/Source/Directors/AudioClockDirector.swift
@@ -26,8 +26,7 @@
 import CoreMedia
 import Foundation
 
-class AudioClockDirector {
-    static let shared = AudioClockDirector()
+public class AudioClockDirector {
     private var currentAudioKey: Key?
 
     private var depNeedleClosures: DirectorThreadSafeClosuresDeprecated<Needle> = DirectorThreadSafeClosuresDeprecated()
@@ -40,7 +39,7 @@ class AudioClockDirector {
     private var playingStatusClosures: DirectorThreadSafeClosures<SAPlayingStatus> = DirectorThreadSafeClosures()
     private var bufferClosures: DirectorThreadSafeClosures<SAAudioAvailabilityRange> = DirectorThreadSafeClosures()
 
-    private init() {}
+    init() {}
 
     func setKey(_ key: Key) {
         currentAudioKey = key

--- a/Source/Directors/AudioQueueDirector.swift
+++ b/Source/Directors/AudioQueueDirector.swift
@@ -7,10 +7,9 @@
 
 import Foundation
 
-class AudioQueueDirector {
-    static let shared = AudioQueueDirector()
+public class AudioQueueDirector {
     var closures: DirectorThreadSafeClosures<URL> = DirectorThreadSafeClosures()
-    private init() {}
+    init() {}
 
     func create() {}
 

--- a/Source/Directors/DownloadProgressDirector.swift
+++ b/Source/Directors/DownloadProgressDirector.swift
@@ -25,13 +25,11 @@
 
 import Foundation
 
-class DownloadProgressDirector {
-    static let shared = DownloadProgressDirector()
-
+public class DownloadProgressDirector {
     var closures: DirectorThreadSafeClosuresDeprecated<Double> = DirectorThreadSafeClosuresDeprecated()
 
-    private init() {
-        AudioDataManager.shared.attach { [weak self] key, progress in
+    init(audioDataManager: AudioDataManager) {
+        audioDataManager.attach { [weak self] key, progress in
             self?.closures.broadcast(key: key, payload: progress)
         }
     }

--- a/Source/Directors/StreamingDownloadDirector.swift
+++ b/Source/Directors/StreamingDownloadDirector.swift
@@ -24,13 +24,12 @@
 
 import Foundation
 
-class StreamingDownloadDirector {
-    static let shared = StreamingDownloadDirector()
+public class StreamingDownloadDirector {
     private var currentAudioKey: Key?
 
     var closures: DirectorThreadSafeClosures<Double> = DirectorThreadSafeClosures()
 
-    private init() {}
+    init() {}
 
     func setKey(_ key: Key) {
         currentAudioKey = key

--- a/Source/Engine/AudioDiskEngine.swift
+++ b/Source/Engine/AudioDiskEngine.swift
@@ -47,7 +47,7 @@ class AudioDiskEngine: AudioEngine {
 
     var audioLengthSeconds: Float = 0
 
-    init(withSavedUrl url: AudioURL, delegate: AudioEngineDelegate?, engine: AVAudioEngine) {
+    init(withSavedUrl url: AudioURL, delegate: AudioEngineDelegate?, engine: AVAudioEngine, audioClockDirector: AudioClockDirector) {
         Log.info(url.key)
 
         do {
@@ -56,7 +56,13 @@ class AudioDiskEngine: AudioEngine {
             Log.monitor(error.localizedDescription)
         }
 
-        super.init(url: url, delegate: delegate, engineAudioFormat: audioFile?.processingFormat ?? AudioEngine.defaultEngineAudioFormat, engine: engine)
+        super.init(
+            url: url,
+            delegate: delegate,
+            engineAudioFormat: audioFile?.processingFormat ?? AudioEngine.defaultEngineAudioFormat,
+            engine: engine,
+            audioClockDirector: audioClockDirector
+        )
 
         if let file = audioFile {
             Log.debug("Audio file exists")

--- a/Source/Model/Downloading/FileStorage.swift
+++ b/Source/Model/Downloading/FileStorage.swift
@@ -65,14 +65,14 @@ struct FileStorage {
 
 extension FileStorage {
     struct Audio {
-        private init() {}
+        private var audioDataManager: AudioDataManager
 
-        private static var directory: FileManager.SearchPathDirectory {
-            return AudioDataManager.shared.downloadDirectory
+        init(audioDataManager: AudioDataManager) {
+            self.audioDataManager = audioDataManager
         }
 
-        static func isStored(_ id: ID) -> Bool {
-            guard let url = locate(id)?.path else {
+        static func isStored(_ id: ID, in directory: FileManager.SearchPathDirectory) -> Bool {
+            guard let url = locate(id, in: directory)?.path else {
                 return false
             }
 
@@ -80,15 +80,15 @@ extension FileStorage {
             return FileManager.default.fileExists(atPath: url)
         }
 
-        static func delete(_ id: ID) {
-            guard let url = locate(id) else {
+        static func delete(_ id: ID, in directory: FileManager.SearchPathDirectory) {
+            guard let url = locate(id, in: directory) else {
                 Log.warn("trying to delete audio file that doesn't exist with id: \(id)")
                 return
             }
             return FileStorage.delete(url)
         }
 
-        static func write(_ id: ID, fileExtension: String, data: Data) {
+        static func write(_ id: ID, fileExtension: String, data: Data, in directory: FileManager.SearchPathDirectory) {
             do {
                 let url = FileStorage.getUrl(givenAName: getAudioFileName(id, fileExtension: fileExtension), inDirectory: directory)
                 try data.write(to: url)
@@ -97,8 +97,8 @@ extension FileStorage {
             }
         }
 
-        static func read(_ id: ID) -> Data? {
-            guard let url = locate(id) else {
+        static func read(_ id: ID, in directory: FileManager.SearchPathDirectory) -> Data? {
+            guard let url = locate(id, in: directory) else {
                 Log.debug("Trying to get data for audio file that doesn't exist: \(id)")
                 return nil
             }
@@ -106,14 +106,14 @@ extension FileStorage {
             return data
         }
 
-        static func locate(_ id: ID) -> URL? {
+        static func locate(_ id: ID, in directory: FileManager.SearchPathDirectory) -> URL? {
             let folderUrls = FileManager.default.urls(for: directory, in: .userDomainMask)
             guard folderUrls.count != 0 else { return nil }
 
             if let urls = try? FileManager.default.contentsOfDirectory(at: folderUrls[0], includingPropertiesForKeys: nil) {
                 for url in urls {
                     if url.absoluteString.contains(id) && url.pathExtension != "" {
-                        _ = getUrl(givenId: id, andFileExtension: url.pathExtension)
+                        _ = getUrl(givenId: id, andFileExtension: url.pathExtension, in: directory)
                         return url
                     }
                 }
@@ -121,7 +121,7 @@ extension FileStorage {
             return nil
         }
 
-        static func getUrl(givenId id: ID, andFileExtension fileExtension: String) -> URL {
+        static func getUrl(givenId id: ID, andFileExtension fileExtension: String, in directory: FileManager.SearchPathDirectory) -> URL {
             let url = FileStorage.getUrl(givenAName: getAudioFileName(id, fileExtension: fileExtension), inDirectory: directory)
             return url
         }

--- a/Source/SAPlayerDownloader.swift
+++ b/Source/SAPlayerDownloader.swift
@@ -33,7 +33,13 @@ public extension SAPlayer {
 
      - Important: Please ensure that you have passed in the background download completion handler in the AppDelegate with `setBackgroundCompletionHandler` to allow for downloading audio while app is in the background.
      */
-    enum Downloader {
+    struct Downloader {
+        private let player: SAPlayer
+
+        public init(player: SAPlayer) {
+            self.player = player
+        }
+
         /**
          Download audio from a remote url. Will save the audio on the device for playback later.
 
@@ -47,9 +53,9 @@ public extension SAPlayer {
          - Parameter completion: Completion handler that will return once the download is successful and complete.
          - Parameter savedUrl: The url of where the audio was saved locally on the device. Will receive once download has completed.
          */
-        public static func downloadAudio(on player: SAPlayer, withRemoteUrl url: URL, completion: @escaping (_ savedUrl: URL, _ error: Error?) -> Void) {
+        public func downloadAudio(withRemoteUrl url: URL, completion: @escaping (_ savedUrl: URL, _ error: Error?) -> Void) {
             player.addUrlToMapping(url: url)
-            AudioDataManager.shared.startDownload(withRemoteURL: url, completion: completion)
+            player.audioDataManager.startDownload(withRemoteURL: url, completion: completion)
         }
 
         /**
@@ -57,8 +63,8 @@ public extension SAPlayer {
 
          - Parameter url: The remote url corresponding to the active download you want to cancel.
          */
-        public static func cancelDownload(withRemoteUrl url: URL) {
-            AudioDataManager.shared.cancelDownload(withRemoteURL: url)
+        public func cancelDownload(withRemoteUrl url: URL) {
+            player.audioDataManager.cancelDownload(withRemoteURL: url)
         }
 
         /**
@@ -68,8 +74,8 @@ public extension SAPlayer {
 
          - Parameter url: The url of the audio to delete from the device.
          */
-        public static func deleteDownloaded(withSavedUrl url: URL) {
-            AudioDataManager.shared.deleteDownload(withLocalURL: url)
+        public func deleteDownloaded(withSavedUrl url: URL) {
+            player.audioDataManager.deleteDownload(withLocalURL: url)
         }
 
         /**
@@ -78,8 +84,8 @@ public extension SAPlayer {
          - Parameter url: The remote url corresponding to the audio file you want to see if downloaded.
          - Returns: Whether of not file at remote url is downloaded on device.
          */
-        public static func isDownloaded(withRemoteUrl url: URL) -> Bool {
-            return AudioDataManager.shared.getPersistedUrl(withRemoteURL: url) != nil
+        public func isDownloaded(withRemoteUrl url: URL) -> Bool {
+            return player.audioDataManager.getPersistedUrl(withRemoteURL: url) != nil
         }
 
         /**
@@ -88,8 +94,8 @@ public extension SAPlayer {
          - Parameter url: The remote url corresponding to the audio file you want the device url of.
          - Returns: Url of audio file on device if it exists.
          */
-        public static func getSavedUrl(forRemoteUrl url: URL) -> URL? {
-            return AudioDataManager.shared.getPersistedUrl(withRemoteURL: url)
+        public func getSavedUrl(forRemoteUrl url: URL) -> URL? {
+            return player.audioDataManager.getPersistedUrl(withRemoteURL: url)
         }
 
         /**
@@ -97,25 +103,25 @@ public extension SAPlayer {
 
          - Parameter completionHandler: The completion hander from `AppDelegate` to use for app in the background downloads.
          */
-        public static func setBackgroundCompletionHandler(_ completionHandler: @escaping () -> Void) {
-            AudioDataManager.shared.setBackgroundCompletionHandler(completionHandler)
+        public func setBackgroundCompletionHandler(_ completionHandler: @escaping () -> Void) {
+            player.audioDataManager.setBackgroundCompletionHandler(completionHandler)
         }
 
         /**
          Whether downloading audio on cellular data is allowed. By default this is set to `true`.
          */
-        public static var allowUsingCellularData = true {
+        public var allowUsingCellularData = true {
             didSet {
-                AudioDataManager.shared.setAllowCellularDownloadPreference(allowUsingCellularData)
+                player.audioDataManager.setAllowCellularDownloadPreference(allowUsingCellularData)
             }
         }
 
         /**
          EXPERIMENTAL!
          */
-        public static var downloadDirectory: FileManager.SearchPathDirectory = .documentDirectory {
+        public var downloadDirectory: FileManager.SearchPathDirectory = .documentDirectory {
             didSet {
-                AudioDataManager.shared.setDownloadDirectory(downloadDirectory)
+                player.audioDataManager.setDownloadDirectory(downloadDirectory)
             }
         }
     }

--- a/Source/SAPlayerFeatures.swift
+++ b/Source/SAPlayerFeatures.swift
@@ -144,7 +144,7 @@ public extension SAPlayer {
 
                 guard playingStatusId == nil else { return }
 
-                playingStatusId = SAPlayer.Updates.PlayingStatus.subscribe { status in
+                playingStatusId = SAPlayer.Updates.PlayingStatus(audioClockDirector: player.audioClockDirector).subscribe { status in
                     if status == .ended, enabled {
                         player.seekTo(seconds: 0.0)
                         player.play()

--- a/Source/SAPlayerUpdateSubscription.swift
+++ b/Source/SAPlayerUpdateSubscription.swift
@@ -29,11 +29,33 @@ public extension SAPlayer {
     /**
      Receive updates for changing values from the player, such as the duration, elapsed time of playing audio, download progress, and etc.
      */
-    enum Updates {
+    struct Updates {
+        public let elapsedTime: ElapsedTime
+        public let duration: Duration
+        public let playingStatus: PlayingStatus
+        public let streamingBuffer: StreamingBuffer
+        public let audioDownloading: AudioDownloading
+        public let audioQueue: AudioQueue
+
+        init(player: SAPlayer) {
+            elapsedTime = .init(audioClockDirector: player.audioClockDirector)
+            duration = .init(audioClockDirector: player.audioClockDirector)
+            playingStatus = .init(audioClockDirector: player.audioClockDirector)
+            streamingBuffer = .init(audioClockDirector: player.audioClockDirector)
+            audioDownloading = .init(downloadProgressDirector: player.downloadProgressDirector)
+            audioQueue = .init(audioQueueDirector: player.audioQueueDirector)
+        }
+
         /**
          Updates to changes in the timestamp/elapsed time of the current initialized audio. Aka, where the scrubber's pointer of the audio should be at.
          */
-        public enum ElapsedTime {
+        public struct ElapsedTime {
+            private var audioClockDirector: AudioClockDirector
+
+            internal init(audioClockDirector: AudioClockDirector) {
+                self.audioClockDirector = audioClockDirector
+            }
+
             /**
              Subscribe to updates in elapsed time of the playing audio. Aka, the current timestamp of the audio.
 
@@ -43,8 +65,8 @@ public extension SAPlayer {
              - Parameter timePosition: The current time within the audio that is playing.
              - Returns: the id for the subscription in the case you would like to unsubscribe to updates for the closure.
              */
-            public static func subscribe(_ closure: @escaping (_ timePosition: Double) -> Void) -> UInt {
-                AudioClockDirector.shared.attachToChangesInNeedle(closure: closure)
+            public func subscribe(_ closure: @escaping (_ timePosition: Double) -> Void) -> UInt {
+                audioClockDirector.attachToChangesInNeedle(closure: closure)
             }
 
             /**
@@ -52,8 +74,8 @@ public extension SAPlayer {
 
              - Parameter id: The closure with this id will stop receiving updates.
              */
-            public static func unsubscribe(_ id: UInt) {
-                AudioClockDirector.shared.detachFromChangesInNeedle(withID: id)
+            public func unsubscribe(_ id: UInt) {
+                audioClockDirector.detachFromChangesInNeedle(withID: id)
             }
         }
 
@@ -62,7 +84,13 @@ public extension SAPlayer {
 
          - Note: If you are streaming from a source that does not have an expected size at the beginning of a stream, such as live streams, duration will be constantly updating to best known value at the time (which is the seconds buffered currently and not necessarily the actual total duration of audio).
          */
-        public enum Duration {
+        public struct Duration {
+            private var audioClockDirector: AudioClockDirector
+
+            internal init(audioClockDirector: AudioClockDirector) {
+                self.audioClockDirector = audioClockDirector
+            }
+
             /**
              Subscribe to updates to changes in duration of the current audio initialized.
 
@@ -74,8 +102,8 @@ public extension SAPlayer {
              - Parameter duration: The duration of the current initialized audio.
              - Returns: the id for the subscription in the case you would like to unsubscribe to updates for the closure.
              */
-            public static func subscribe(_ closure: @escaping (_ duration: Double) -> Void) -> UInt {
-                return AudioClockDirector.shared.attachToChangesInDuration(closure: closure)
+            public func subscribe(_ closure: @escaping (_ duration: Double) -> Void) -> UInt {
+                return audioClockDirector.attachToChangesInDuration(closure: closure)
             }
 
             /**
@@ -83,15 +111,21 @@ public extension SAPlayer {
 
              - Parameter id: The closure with this id will stop receiving updates.
              */
-            public static func unsubscribe(_ id: UInt) {
-                AudioClockDirector.shared.detachFromChangesInDuration(withID: id)
+            public func unsubscribe(_ id: UInt) {
+                audioClockDirector.detachFromChangesInDuration(withID: id)
             }
         }
 
         /**
          Updates to changes in the playing/paused status of the player.
          */
-        public enum PlayingStatus {
+        public struct PlayingStatus {
+            private var audioClockDirector: AudioClockDirector
+
+            internal init(audioClockDirector: AudioClockDirector) {
+                self.audioClockDirector = audioClockDirector
+            }
+
             /**
              Subscribe to updates to changes in the playing/paused status of audio.
 
@@ -101,8 +135,8 @@ public extension SAPlayer {
              - Parameter playingStatus: Whether the player is playing audio or paused.
              - Returns: the id for the subscription in the case you would like to unsubscribe to updates for the closure.
              */
-            public static func subscribe(_ closure: @escaping (_ playingStatus: SAPlayingStatus) -> Void) -> UInt {
-                return AudioClockDirector.shared.attachToChangesInPlayingStatus(closure: closure)
+            public func subscribe(_ closure: @escaping (_ playingStatus: SAPlayingStatus) -> Void) -> UInt {
+                return audioClockDirector.attachToChangesInPlayingStatus(closure: closure)
             }
 
             /**
@@ -110,15 +144,21 @@ public extension SAPlayer {
 
              - Parameter id: The closure with this id will stop receiving updates.
              */
-            public static func unsubscribe(_ id: UInt) {
-                AudioClockDirector.shared.detachFromChangesInPlayingStatus(withID: id)
+            public func unsubscribe(_ id: UInt) {
+                audioClockDirector.detachFromChangesInPlayingStatus(withID: id)
             }
         }
 
         /**
          Updates to changes in the progress of downloading audio for streaming. Information about range of audio available and if the audio is playable. Look at `SAAudioAvailabilityRange` for more information.
          */
-        public enum StreamingBuffer {
+        public struct StreamingBuffer {
+            private var audioClockDirector: AudioClockDirector
+
+            internal init(audioClockDirector: AudioClockDirector) {
+                self.audioClockDirector = audioClockDirector
+            }
+
             /**
              Subscribe to updates to changes in the progress of downloading audio for streaming. Information about range of audio available and if the audio is playable. Look at SAAudioAvailabilityRange for more information. For progress of downloading audio that saves to the phone for playback later, look at AudioDownloading instead.
 
@@ -130,8 +170,8 @@ public extension SAPlayer {
              - Parameter buffer: Availabity of audio that has been downloaded to play.
              - Returns: the id for the subscription in the case you would like to unsubscribe to updates for the closure.
              */
-            public static func subscribe(_ closure: @escaping (_ buffer: SAAudioAvailabilityRange) -> Void) -> UInt {
-                return AudioClockDirector.shared.attachToChangesInBufferedRange(closure: closure)
+            public func subscribe(_ closure: @escaping (_ buffer: SAAudioAvailabilityRange) -> Void) -> UInt {
+                return audioClockDirector.attachToChangesInBufferedRange(closure: closure)
             }
 
             /**
@@ -139,15 +179,21 @@ public extension SAPlayer {
 
              - Parameter id: The closure with this id will stop receiving updates.
              */
-            public static func unsubscribe(_ id: UInt) {
-                AudioClockDirector.shared.detachFromChangesInBufferedRange(withID: id)
+            public func unsubscribe(_ id: UInt) {
+                audioClockDirector.detachFromChangesInBufferedRange(withID: id)
             }
         }
 
         /**
          Updates to changes in the progress of downloading audio in the background. This does not correspond to progress in streaming downloads, look at StreamingBuffer for streaming progress.
          */
-        public enum AudioDownloading {
+        public struct AudioDownloading {
+            private var downloadProgressDirector: DownloadProgressDirector
+
+            init(downloadProgressDirector: DownloadProgressDirector) {
+                self.downloadProgressDirector = downloadProgressDirector
+            }
+
             /**
              Subscribe to updates to changes in the progress of downloading audio. This does not correspond to progress in streaming downloads, look at StreamingBuffer for streaming progress.
 
@@ -158,8 +204,8 @@ public extension SAPlayer {
              - Parameter progress: Value from 0.0 to 1.0 indicating progress of download.
              - Returns: the id for the subscription in the case you would like to unsubscribe to updates for the closure.
              */
-            public static func subscribe(on player: SAPlayer, _ closure: @escaping (_ url: URL, _ progress: Double) -> Void) -> UInt {
-                return DownloadProgressDirector.shared.attach(closure: { key, progress in
+            public func subscribe(on player: SAPlayer, _ closure: @escaping (_ url: URL, _ progress: Double) -> Void) -> UInt {
+                return downloadProgressDirector.attach(closure: { key, progress in
                     guard let url = player.getUrl(forKey: key) else { return }
                     closure(url, progress)
                 })
@@ -170,12 +216,18 @@ public extension SAPlayer {
 
              - Parameter id: The closure with this id will stop receiving updates.
              */
-            public static func unsubscribe(_ id: UInt) {
-                DownloadProgressDirector.shared.detach(withID: id)
+            public func unsubscribe(_ id: UInt) {
+                downloadProgressDirector.detach(withID: id)
             }
         }
 
-        public enum AudioQueue {
+        public struct AudioQueue {
+            private var audioQueueDirector: AudioQueueDirector
+
+            internal init(audioQueueDirector: AudioQueueDirector) {
+                self.audioQueueDirector = audioQueueDirector
+            }
+
             /**
              Subscribe to updates to changes in the progress of your audio queue. When streaming audio playback completes
              and continues onto the next track, the closure is invoked.
@@ -184,16 +236,16 @@ public extension SAPlayer {
              - Parameter url: The corresponding remote URL for the forthcoming audio file.
              - Returns: the id for the subscription in the case you would like to unsubscribe to updates for the closure.
              */
-            public static func subscribe(_ closure: @escaping (_ newUrl: URL) -> Void) -> UInt {
-                return AudioQueueDirector.shared.attach(closure: closure)
+            public func subscribe(_ closure: @escaping (_ newUrl: URL) -> Void) -> UInt {
+                return audioQueueDirector.attach(closure: closure)
             }
 
             /**
              Stop recieving updates of changes in download progress.
              - Parameter id: The closure with this id will stop receiving updates.
              */
-            public static func unsubscribe(_ id: UInt) {
-                AudioQueueDirector.shared.detach(withID: id)
+            public func unsubscribe(_ id: UInt) {
+                audioQueueDirector.detach(withID: id)
             }
         }
     }


### PR DESCRIPTION
Updates subscriptions where still "shared" between multiple instances of the player, that was causing subscribers for a possible player 1 instance receiving updates from a possible player 2 instance (ex. if we paused player 2 also subscribers of player 1 would get a pause change).

So now all updates must be listened on the player instance, Ex.
```swift
player.updates.duration.subscribe {
}
```
instead of 
```swift
SAPlayer.Updates.Duration.subscribe {
}
```